### PR TITLE
Week05 문제 풀이 / cutiepepe2926

### DIFF
--- a/cutiepepe2926/week_05/구명보트/Solution.java
+++ b/cutiepepe2926/week_05/구명보트/Solution.java
@@ -1,0 +1,24 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[] people, int limit) {
+
+        Arrays.sort(people);
+
+        int answer = 0;
+
+        for (int i = 0, j = people.length - 1; i < people.length && j >= 0;) {
+            if (i > j) break;
+            if (people[i] + people[j] <= limit) {
+                answer++;
+                i++; j--;
+            }
+            else {
+                answer++;
+                j--;
+            }
+        }
+
+        return answer;
+    }
+}

--- a/cutiepepe2926/week_05/연속 부분 수열 합의 개수/Solution.java
+++ b/cutiepepe2926/week_05/연속 부분 수열 합의 개수/Solution.java
@@ -1,0 +1,27 @@
+class Solution {
+    public int[] solution(int[] sequence, int k) {
+
+        int[] answer = {0, sequence.length - 1};
+
+        int left = 0;
+        int sum = 0;
+
+        for (int right = 0; right < sequence.length; right++) {
+
+            sum += sequence[right];
+
+            while (sum > k) {
+                sum -= sequence[left++];
+            }
+
+            if (sum == k) {
+                if (right - left < answer[1] - answer[0]) {
+                    answer[0] = left;
+                    answer[1] = right;
+                }
+            }
+        }
+
+        return answer;
+    }
+}

--- a/cutiepepe2926/week_05/연속된 부분 수열의 합/Solution.java
+++ b/cutiepepe2926/week_05/연속된 부분 수열의 합/Solution.java
@@ -1,0 +1,28 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[] elements) {
+
+        HashSet<Integer> answer = new HashSet<>();
+
+        int n = elements.length;
+
+        // 구간 별
+        for (int cp = 1; cp <= n; cp++) {
+
+            // 시작 별
+            for (int start = 0; start < n; start++) {
+
+                int sum = 0;
+
+                for (int i = 0; i < cp; i++) {
+                    sum += elements[(start + i) % n];
+                }
+
+                answer.add(sum);
+            }
+        }
+
+        return answer.size();
+    }
+}


### PR DESCRIPTION
## Week05 문제 풀이

- #34 

### 📌 이번 주 문제 목록

* [x] 연속 부분 수열 합의 개수
* [x] 연속된 부분 수열의 합
* [x] 구명보트

---

## 1️⃣ 구명보트

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/42885?gad_source=1&gad_campaignid=23716289893&gbraid=0AAAAAC_c4nDwqilumZP58gpXekQFgYIz9&gclid=Cj0KCQjw2MbPBhCSARIsAP3jP9yPch-mRI0UmnEmuSNgAcJNzP4-PJpUSSW3YEutw_T5dxog2QIdT_kaAjO4EALw_wcB

### 🤖 핵심 알고리즘

구현, 투 포인터

### 💻 풀이 코드

```java
import java.util.*;

class Solution {
    public int solution(int[] people, int limit) {
        
        Arrays.sort(people);
        
        int answer = 0;
        
        for (int i = 0, j = people.length - 1; i < people.length && j >= 0;) {
            if (i > j) break;
            if (people[i] + people[j] <= limit) {
                answer++;
                i++; j--;
            }
            else {
                answer++;
                j--;
            }
        }
        
        return answer;
    }
}
```

### 🤔 풀이 방법

해당 문제는 구명보트를 최대한 적게 사용하여 모든 사람을 구출하는 것이 핵심인 문제입니다.

구명 보트를 최대한 적게 사용하기 위해서는 최대 2명씩 태워서 보내는 것이 중요하다고 판단해, 정렬을 우선 수행했습니다.

그렇게 된다면, 가장 적은 몸무게를 가진 사람들 순으로 줄이 세워지게 되는데, 이때 투 포인터를 활용해 반복문을 수행하도록 했습니다.

가장 적은 몸무게를 가르키는 i 와 가장 많은 몸무게를 가르키는 j에 대해서 주어진 배열 내에서 i와 j가 가르키는 사람의 몸무게가 

limit보다 작거나 같으면 그대로 태워서 사람들을 보내고 각 포인터 i 와 j 에 대해서 이동하게 됩니다. (i는 증가, j는 감소)

그 외의 경우라면, 나올 수 있는 경우의 수는 2명의 몸무게가 초과이므로 가장 큰 몸무게를 가진 j에 대해서만 보트를 보내고

j 포인터를 감소시켜서 최종적으로 i와 j 포인터가 서로 엇갈리는 경우(i > j) 멈추도록 지정해 반복문을 멈추게해서 문제를 풀었습니다.

---

## 2️⃣ 연속된 부분 수열의 합

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/178870

### 🤖 핵심 알고리즘

구현, 투 포인터, 슬라이딩

### 💻 풀이 코드

```java
class Solution {
    public int[] solution(int[] sequence, int k) {
        int[] answer = {0, sequence.length - 1};

        int left = 0;
        int sum = 0;

        for (int right = 0; right < sequence.length; right++) {
            
            sum += sequence[right];

            while (sum > k) {
                sum -= sequence[left++];
            }

            if (sum == k) {
                if (right - left < answer[1] - answer[0]) {
                    answer[0] = left;
                    answer[1] = right;
                }
            }
        }

        return answer;
    }
}
```

### 🤔 풀이 방법

이 문제는 연속된 부분 수열의 합이 k가 되는 구간 중 길이가 가장 짧은 구간을 찾는 것이 핵심입니다.

주어진 배열 sequence의 경우, 이미 정렬이 되었기 때문에 따로 정렬할 필요는 없다고 판단했습니다.

우선, 정답 구간에 대해서 sequence의 length 만큼으로 지정해두고 (이후 가장 작은 값인지 비교하기 위해 필요함)

투 포인터를 사용하기 위해 left와 right 포인터와 구간 합을 저장하기 위한 sum 변수를 이용해 반복문을 구성했습니다.

반복문에서는 sum을 통해 현재 구간의 총 합을 나타내고, 만약에 sum이 목표치인 k보다 큰 경우라면

k보다 작아질 때까지, 좌측 포인터인 left에 대해서 해당 값을 sum에서 제거하고 한칸 옮기게 됩니다.

이후에 sum == k를 만족하는 경우, 기존 answer에 담긴 구간과 현재 구간이 큰 지 작은 지 비교 후 작다면, 정답으로 추가하게 됩니다.

이후 포인터가 끝까지 닿게 되면 최종적으로 가장 짧은 구간 값을 반환하게 됩니다.



### ☄️ 트러블 슈팅

처음 코드를 작성했을 때, 결과값에 대해서 가장 짧은 결과값인지 판단하는 코드가 없어, 합이 k가 되는 구간에 대해서 찾긴 했으나 정답이 아닌 구간을 찾게 되는 문제가 발생했습니다. 이후에 sum == k가 된다고 바로 break를 걸지 않고, 현재 구간의 길이와 이전에 찾았던 정답을 비교하도록 코드를 추가해 문제를 해결할 수 있었습니다.

---

## 3️⃣ 연속 부분 수열 합의 개수

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/131701

### 🤖 핵심 알고리즘

구현

### 💻 풀이 코드

```java
import java.util.*;

class Solution {
    public int solution(int[] elements) {
        
        HashSet<Integer> answer = new HashSet<>();
        
        int n = elements.length;

        // 구간 별
        for (int cp = 1; cp <= n; cp++) {
        
            // 시작 별
            for (int start = 0; start < n; start++) {
            
                int sum = 0;

                for (int i = 0; i < cp; i++) {
                    sum += elements[(start + i) % n];
                }

                answer.add(sum);
            }
        }

        return answer.size();
    }
}
```

### 🤔 풀이 방법

해당 문제는 원형 수열에서 만들 수 있는 연속 부분 수열의 합 종류 개수를 구하는 것이 핵심입니다.

다만, 주어지는 데이터는 단순한 1차원 배열이기 때문에 원형 수열처럼 처리하기 위해 인덱스 계산에 '%' 를 이용하기로 했습니다.

우선, 원형 수열의 경우, 중복되는 값들이 나올 수 있기 때문에 이를 방지하고자 HashSet 자료구조를 이용해 중복을 제거하도록 했습니다.

이후 구간 별로 for 문을 수행하게 하고, 각 구간 별 길이의 시작 위치를 나타내도록 start를 이용해 반복문을 돌도록 구성했습니다.

이때, sum은 수열의 합을 저장하기 위한 변수이고, 마지막 for문은 원형 수열에서 start 위치부터 cp구간까지 만큼의 연속된 값을 더하는 반복문입니다.

이때, elemenets의 인덱스에 대해서 start + i를 하게 된다면 분명히 구간을 넘어가므로 나머지 연산인 '% n' 을 이용해 원형인 것처럼 돌도록 구성했습니다.

최종적으로 HashSEt의 크기를 반환해 중복이 없는 고유한 값만 반환하도록 해서 문제를 해결했습니다.

### ☄️ 트러블 슈팅

해당 문제를 풀 때, 주어지는 데이터 크기가 최대 1000이여서 Deque로 풀 수 있지 않을까 생각하여 Deque 방식으로 문제를 풀었습니다. 

그러나, 데이터를 추가하고 빼는 과정이 많아지면서 일부 테스트 케이스에서 시간 초과가 발생했습니다. 

이후 Deque 방식은 비효율적이라고 판단해 Deque 방식이 아니라 % 를 이용해 원형처럼 처리하도록 위 풀이 방법을 사용해 문제를 해결할 수 있었습니다.

---