### PR TITLE
Week05 문제 풀이 / Anchovia

### DIFF
--- a/Anchovia/week_05/구명보트/Solution.py
+++ b/Anchovia/week_05/구명보트/Solution.py
@@ -1,0 +1,25 @@
+from collections import deque
+
+def solution(people, limit):
+    answer = 0
+    people.sort() # 몸무게 순으로 오름차순 정렬
+    deq = deque(people)
+
+    while deq:
+        # 1명만 남은 경우 혼자 타고 감
+        if len(deq) == 1:
+            answer += 1
+            break
+            
+        # 가장 가벼운 사람 + 가장 무거운 사람 <= limit
+        if deq[0] + deq[-1] <= limit:
+            deq.popleft() # 가벼운 사람
+            deq.pop()     # 무거운 사람
+        else:
+            # 같이 못 타면 무거운 사람만
+            deq.pop()     
+            
+        # 보트 출발
+        answer += 1
+
+    return answer

--- a/Anchovia/week_05/연속 부분 수열 합의 개수/Solution.py
+++ b/Anchovia/week_05/연속 부분 수열 합의 개수/Solution.py
@@ -1,0 +1,13 @@
+def solution(elements):
+    answerSet = set()
+    elemExtend = elements + elements
+    
+    # idx는 부분 수열의 시작점 (0부터 원래 배열의 끝까지)
+    for idx in range(len(elements)):
+        # selectLen은 부분 수열의 길이 (1부터 원래 배열의 길이까지)
+        for selectLen in range(1, len(elements) + 1):
+            # 슬라이싱을 이용해 i부터 i+selectLen까지 자르고 합을 구함
+            sub_sum = sum(elemExtend[idx : idx + selectLen])
+            answerSet.add(sub_sum)
+            
+    return len(answerSet)

--- a/Anchovia/week_05/연속된 부분 수열의 합/Solution.py
+++ b/Anchovia/week_05/연속된 부분 수열의 합/Solution.py
@@ -1,0 +1,32 @@
+def solution(sequence, k):
+    answer = []
+    
+    start = 0
+    end = 0
+    sum = sequence[0]
+    minLen = 10000001
+    
+    while start <= end and end < len(sequence):
+        # k와 같은 경우
+        if sum == k:
+            # 현재 찾은 수열의 길이가 기존에 찾은 길이보다 짧다면 바꿈(minLen)
+            if end - start < minLen:
+                minLen = end - start
+                answer = [start, end]
+            
+            # 다음 경우의 수를 찾기 위해 start를 한 칸 이동
+            sum -= sequence[start]
+            start += 1
+            
+        # 합이 k보다 작은 경우 end를 오른쪽으로 이동(값을 늘려야함)
+        elif sum < k:
+            end += 1
+            if end < len(sequence):
+                sum += sequence[end]
+                
+        # 합이 k보다 큰 경우 start를 오른쪽으로 이동(값을 줄여야함)
+        else:
+            sum -= sequence[start]
+            start += 1
+            
+    return answer


### PR DESCRIPTION
## Week05 문제 풀이

- #34 

### 📌 이번 주 문제 목록

* [x] 연속된 부분 수열의 합
* [x] 연속 부분 수열 합의 개수
* [x] 구명보트

---

## 1️⃣ 연속된 부분 수열의 합

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/178870

### 🤖 핵심 알고리즘

투포인터

### 💻 풀이 코드

```python
def solution(sequence, k):
    answer = []
    
    start = 0
    end = 0
    sum = sequence[0]
    minLen = 10000001
    
    while start <= end and end < len(sequence):
        # k와 같은 경우
        if sum == k:
            # 현재 찾은 수열의 길이가 기존에 찾은 길이보다 짧다면 바꿈(minLen)
            if end - start < minLen:
                minLen = end - start
                answer = [start, end]
            
            # 다음 경우의 수를 찾기 위해 start를 한 칸 이동
            sum -= sequence[start]
            start += 1
            
        # 합이 k보다 작은 경우 end를 오른쪽으로 이동(값을 늘려야함)
        elif sum < k:
            end += 1
            if end < len(sequence):
                sum += sequence[end]
                
        # 합이 k보다 큰 경우 start를 오른쪽으로 이동(값을 줄여야함)
        else:
            sum -= sequence[start]
            start += 1
            
    return answer
```

### 🤔 풀이 방법

이전 발표에서 다뤘던 문제들과 비슷하게, 동방향 투포인터의 기본 문제와 비슷하기 때문에
이와 비슷한 풀이로 풀었습니다.

1. 따라서, 합이 작으면 end를 오른쪽으로 이동해 값을 늘리고
2. 합이 크면 start를 오른쪽으로 이동해 값을 줄이는 로직으로
3. 찾은 수열의 길이가 기존 길이보다 짧으면 answer list를 바꾸는 식으로 구현했습니다.

---

## 2️⃣ 연속 부분 수열 합의 개수

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/131701

### 🤖 핵심 알고리즘

구현

### 💻 풀이 코드

```python
def solution(elements):
    answerSet = set()
    elemExtend = elements + elements
    
    # idx는 부분 수열의 시작점 (0부터 원래 배열의 끝까지)
    for idx in range(len(elements)):
        # selectLen은 부분 수열의 길이 (1부터 원래 배열의 길이까지)
        for selectLen in range(1, len(elements) + 1):
            # 슬라이싱을 이용해 i부터 i+selectLen까지 자르고 합을 구함
            sub_sum = sum(elemExtend[idx : idx + selectLen])
            answerSet.add(sub_sum)
            
    return len(answerSet)
```

### 🤔 풀이 방법

배열이 원형으로 연결되어 있다고 합니다.
하지만, limit 길이는 시작과 시작 전 까지가 최대이기 때문에,
배열 두개를 연결하면 슬라이싱을 통해 편하게 구현할 수 있습니다.

1. 따라서, extended List를 하나 만들어주고
2. 1부터 배열의 길이까지의 수열 모음들을 만들어
3. 그 합을 set 자료형에 집어넣어 중복을 제거한 후
4. 그 set의 원소의 갯수를 반환하도록 구현했습니다.

### ☄️ 트러블 슈팅

deque로도 할까 고민을 했는데 하다가 너무 복잡해져가지고,
그냥 배열 두개를 연결해 연장해서 슬라이싱 하는걸로 해결했습니다.

---

## 3️⃣ 구명보트

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/42885

### 🤖 핵심 알고리즘

그리디

### 💻 풀이 코드

```python
from collections import deque

def solution(people, limit):
    answer = 0
    people.sort() # 몸무게 순으로 오름차순 정렬
    deq = deque(people)

    while deq:
        # 1명만 남은 경우 혼자 타고 감
        if len(deq) == 1:
            answer += 1
            break
            
        # 가장 가벼운 사람 + 가장 무거운 사람 <= limit
        if deq[0] + deq[-1] <= limit:
            deq.popleft() # 가벼운 사람
            deq.pop()     # 무거운 사람
        else:
            # 같이 못 타면 무거운 사람만
            deq.pop()     
            
        # 보트 출발
        answer += 1

    return answer
```

### 🤔 풀이 방법

이 문제의 핵심은 최소 횟수로 왔다 갔다 거리는 것이고,
특히, 1회 이동 당 최대 2명만 옮길 수 있다는 것입니다.

가장 무거운 사람과 가장 가벼운 사람을 같이 묶어서 가면 최대로 보낼 수 있기 때문에,

1. 처음 주어진 리스트를 정렬 한 후
5. 무거운 사람을 빼고
6. 같이 탈 수 있으면, 가벼운 사람도 빼서 보내게 만들었습니다.