### PR TITLE
Week08 문제 풀이 / WhiteBin-bin

### DIFF
--- a/WhiteBin-bin/week_08/네트워크/Solution.java
+++ b/WhiteBin-bin/week_08/네트워크/Solution.java
@@ -1,0 +1,35 @@
+class Solution {
+    
+    static boolean[] visited;
+    
+    public int solution(int n, int[][] computers) {
+        
+        visited = new boolean[n];
+        
+        int answer = 0;
+        
+        for (int i = 0; i < n; i++) {
+            if (!visited[i]) {
+                dfs(i, n, computers);
+                answer++;
+            }
+        }
+        
+        return answer;
+    }
+    
+    private void dfs(int current, int n, int[][] computers) {
+        visited[current] = true;
+        
+        for (int next = 0; next < n; next++) {
+            
+            if (current == next) {
+                continue;
+            }
+            
+            if (computers[current][next] == 1 && !visited[next]) {
+                dfs(next, n, computers);
+            }
+        }
+    }
+}

--- a/WhiteBin-bin/week_08/무인도 여행/Solution.java
+++ b/WhiteBin-bin/week_08/무인도 여행/Solution.java
@@ -1,0 +1,70 @@
+import java.util.*;
+
+class Solution {
+
+    static int n, m;
+    static boolean[][] visited;
+
+    static int[] dx = {-1, 1, 0, 0};
+    static int[] dy = {0, 0, -1, 1};
+
+    public int[] solution(String[] maps) {
+        n = maps.length;
+        m = maps[0].length();
+
+        visited = new boolean[n][m];
+
+        List<Integer> result = new ArrayList<>();
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+
+                if (maps[i].charAt(j) != 'X' && !visited[i][j]) {
+                    int sum = dfs(i, j, maps);
+                    result.add(sum);
+                }
+            }
+        }
+
+        if (result.isEmpty()) {
+            return new int[]{-1};
+        }
+
+        Collections.sort(result);
+
+        int[] answer = new int[result.size()];
+
+        for (int i = 0; i < result.size(); i++) {
+            answer[i] = result.get(i);
+        }
+
+        return answer;
+    }
+
+    private int dfs(int x, int y, String[] maps) {
+        visited[x][y] = true;
+
+        int sum = maps[x].charAt(y) - '0';
+
+        for (int i = 0; i < 4; i++) {
+            int nx = x + dx[i];
+            int ny = y + dy[i];
+
+            if (nx < 0 || nx >= n || ny < 0 || ny >= m) {
+                continue;
+            }
+
+            if (maps[nx].charAt(ny) == 'X') {
+                continue;
+            }
+
+            if (visited[nx][ny]) {
+                continue;
+            }
+
+            sum += dfs(nx, ny, maps);
+        }
+
+        return sum;
+    }
+}

--- a/WhiteBin-bin/week_08/피로도/Solution.java
+++ b/WhiteBin-bin/week_08/피로도/Solution.java
@@ -1,0 +1,27 @@
+class Solution {
+    
+    int answer = 0;
+    boolean[] visited;
+
+    public int solution(int k, int[][] dungeons) {
+        
+        visited = new boolean[dungeons.length];
+        dfs(k, dungeons, 0);
+        return answer;
+    }
+
+    private void dfs(int k, int[][] dungeons, int count) {
+        
+        answer = Math.max(answer, count);
+
+        for (int i = 0; i < dungeons.length; i++) {
+            
+            if (!visited[i] && k >= dungeons[i][0]) {
+                
+                visited[i] = true;
+                dfs(k - dungeons[i][1], dungeons, count + 1);
+                visited[i] = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Week08 문제 풀이

- #55 

### 📌 이번 주 문제 목록

* [x] 무인도 여행
* [x] 네트워크
* [x] 피로도

---

## 1️⃣ 무인도 여행

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/154540

### 🤖 핵심 알고리즘

DFS

### 💻 풀이 코드

```java
import java.util.*;

class Solution {

    static int n, m;
    static boolean[][] visited;

    static int[] dx = {-1, 1, 0, 0};
    static int[] dy = {0, 0, -1, 1};

    public int[] solution(String[] maps) {
        n = maps.length;
        m = maps[0].length();

        visited = new boolean[n][m];

        List<Integer> result = new ArrayList<>();

        for (int i = 0; i < n; i++) {
            for (int j = 0; j < m; j++) {

                if (maps[i].charAt(j) != 'X' && !visited[i][j]) {
                    int sum = dfs(i, j, maps);
                    result.add(sum);
                }
            }
        }

        if (result.isEmpty()) {
            return new int[]{-1};
        }

        Collections.sort(result);

        int[] answer = new int[result.size()];

        for (int i = 0; i < result.size(); i++) {
            answer[i] = result.get(i);
        }

        return answer;
    }

    private int dfs(int x, int y, String[] maps) {
        visited[x][y] = true;

        int sum = maps[x].charAt(y) - '0';

        for (int i = 0; i < 4; i++) {
            int nx = x + dx[i];
            int ny = y + dy[i];

            if (nx < 0 || nx >= n || ny < 0 || ny >= m) {
                continue;
            }

            if (maps[nx].charAt(ny) == 'X') {
                continue;
            }

            if (visited[nx][ny]) {
                continue;
            }

            sum += dfs(nx, ny, maps);
        }

        return sum;
    }
}
```

### 🤔 풀이 방법

1. 이 문제는 지도 `maps`에서 바다가 아닌 숫자 칸끼리 상하좌우로 연결된 영역을 하나의 무인도로 보고, 각 무인도에서 머물 수 있는 총 일수를 구하는 문제입니다.
2. 각 칸의 숫자는 해당 칸에서 머물 수 있는 일수를 의미하므로, 연결된 숫자 칸들을 모두 탐색하면서 값을 더해야 한다고 생각했습니다.
3. 연결된 영역을 탐색하는 문제이기 때문에 DFS를 사용했고, 이미 확인한 칸을 다시 방문하지 않도록 `visited` 배열을 만들었습니다.
4. 전체 지도를 이중 반복문으로 돌면서 현재 칸이 `'X'`가 아니고 아직 방문하지 않은 칸이라면 새로운 무인도를 발견한 것이므로 DFS를 시작했습니다.
5. DFS에서는 현재 위치를 방문 처리한 뒤, 현재 칸의 문자 숫자를 정수로 바꾸기 위해 `maps[x].charAt(y) - '0'`을 사용해 `sum`에 저장했습니다.
6. 이후 상하좌우 네 방향을 확인하면서 지도 범위를 벗어나거나, 바다인 `'X'`이거나, 이미 방문한 칸이면 건너뛰도록 했습니다.
7. 이동할 수 있는 숫자 칸이라면 재귀적으로 DFS를 호출하고, 반환된 값을 `sum`에 더해 하나의 무인도에서 머물 수 있는 총 일수를 계산했습니다.
8. DFS가 끝나면 해당 무인도의 총합을 `result` 리스트에 저장하고, 모든 탐색이 끝난 뒤 무인도가 없다면 `-1`을 반환했습니다.
9. 무인도가 하나 이상 있다면 문제에서 요구한 대로 결과를 오름차순 정렬한 뒤, `List<Integer>`를 `int[]`로 변환해 반환했습니다.

### ☄️ 트러블 슈팅

처음에는 숫자가 있는 칸을 발견할 때마다 바로 값을 더하면 된다고 생각할 수 있지만, 이 문제는 서로 연결된 숫자 칸들을 하나의 무인도로 묶어서 합계를 구해야 하므로 단순히 전체 숫자의 합을 구하면 각 무인도별 결과를 분리할 수 없는 문제가 있었습니다.

그래서 방문하지 않은 숫자 칸을 만날 때마다 DFS를 시작해 하나의 연결된 영역만 탐색하도록 처리했으며, 
탐색 과정에서 `visited`로 중복 방문을 막고 상하좌우 범위 검사와 `'X'` 여부를 확인해 같은 무인도에 속한 
칸들의 합만 계산한 뒤, 무인도가 없는 경우에는 `new int[]{-1}`을 반환하도록 구현했습니다.

---

## 2️⃣ 네트워크

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/43162

### 🤖 핵심 알고리즘

DFS

### 💻 풀이 코드

```java
class Solution {
    
    static boolean[] visited;
    
    public int solution(int n, int[][] computers) {
        
        visited = new boolean[n];
        
        int answer = 0;
        
        for (int i = 0; i < n; i++) {
            if (!visited[i]) {
                dfs(i, n, computers);
                answer++;
            }
        }
        
        return answer;
    }
    
    private void dfs(int current, int n, int[][] computers) {
        visited[current] = true;
        
        for (int next = 0; next < n; next++) {
            
            if (current == next) {
                continue;
            }
            
            if (computers[current][next] == 1 && !visited[next]) {
                dfs(next, n, computers);
            }
        }
    }
}
```

### 🤔 풀이 방법

1. 이 문제는 `n`개의 컴퓨터가 주어졌을 때, 서로 연결된 컴퓨터들을 하나의 네트워크로 보고 전체 네트워크의 개수를 구하는 문제입니다.
2. `computers[i][j]`가 `1`이면 `i`번 컴퓨터와 `j`번 컴퓨터가 연결되어 있다는 의미이므로, 하나의 컴퓨터에서 시작해 연결된 컴퓨터들을 모두 탐색하면 하나의 네트워크를 찾을 수 있다고 생각했습니다.
3. 이미 확인한 컴퓨터를 다시 탐색하지 않기 위해 `visited` 배열을 사용했습니다.
4. `solution()`에서는 `0`번 컴퓨터부터 `n - 1`번 컴퓨터까지 반복하면서 아직 방문하지 않은 컴퓨터를 찾았습니다.
5. 방문하지 않은 컴퓨터를 발견했다는 것은 새로운 네트워크를 발견했다는 의미이므로, 해당 컴퓨터를 시작점으로 DFS를 실행했습니다.
6. DFS에서는 현재 컴퓨터를 방문 처리한 뒤, 다른 모든 컴퓨터를 확인하면서 현재 컴퓨터와 연결되어 있고 아직 방문하지 않은 컴퓨터라면 재귀적으로 탐색했습니다.
7. DFS가 끝나면 시작 컴퓨터와 연결된 모든 컴퓨터가 방문 처리되므로, 하나의 네트워크 탐색이 끝난 것으로 보고 `answer`를 증가시켰습니다.
8. 모든 컴퓨터를 확인한 뒤 `answer`를 반환하면 전체 네트워크의 개수를 구할 수 있습니다.

### ☄️ 트러블 슈팅

처음에는 `computers[i][j]`가 `1`인 개수를 세면 네트워크 개수를 구할 수 있다고 생각할 수 있지만, 네트워크는 직접 연결뿐만 아니라 간접적으로 연결된 컴퓨터들도 하나로 묶어야 하므로 단순히 연결 개수만 세면 올바른 네트워크 개수를 구할 수 없는 문제가 있었습니다.

그래서 방문하지 않은 컴퓨터를 만날 때마다 DFS를 시작해 그 컴퓨터와 직접 또는 간접적으로 연결된 모든 컴퓨터를 한 번에 방문 처리하도록 수정했으며, 이미 방문한 컴퓨터는 기존 네트워크에 포함된 것이므로 다시 세지 않고, DFS를 새로 시작하는 횟수만 `answer`에 반영해 네트워크 개수를 계산하도록 구현했습니다.

---

## 3️⃣ 피로도

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/87946

### 🤖 핵심 알고리즘

Backtracking, DFS

### 💻 풀이 코드

```java
class Solution {
    
    int answer = 0;
    boolean[] visited;

    public int solution(int k, int[][] dungeons) {
        
        visited = new boolean[dungeons.length];
        dfs(k, dungeons, 0);
        return answer;
    }

    private void dfs(int k, int[][] dungeons, int count) {
        
        answer = Math.max(answer, count);

        for (int i = 0; i < dungeons.length; i++) {
            
            if (!visited[i] && k >= dungeons[i][0]) {
                
                visited[i] = true;
                dfs(k - dungeons[i][1], dungeons, count + 1);
                visited[i] = false;
            }
        }
    }
}
```

### 🤔 풀이 방법

1. 이 문제는 현재 피로도 `k`를 가지고 최대한 많은 던전을 탐험하는 문제입니다.
2. 각 던전은 `최소 필요 피로도`와 `소모 피로도`를 가지고 있습니다.
3. 던전을 탐험하는 순서에 따라 결과가 달라질 수 있으므로, 가능한 모든 탐험 순서를 확인해야 한다고 생각했습니다.
4. 따라서 DFS를 사용하여 방문하지 않은 던전들을 하나씩 선택하며 탐험 가능한 경우를 모두 확인했습니다.
5. 현재 피로도 `k`가 던전의 최소 필요 피로도 이상이면 해당 던전을 탐험할 수 있습니다.
6. 던전을 탐험한 뒤에는 `소모 피로도`만큼 현재 피로도를 감소시키고, 탐험 횟수 `count`를 1 증가시켰습니다.
7. DFS를 진행할 때마다 `answer = Math.max(answer, count)`를 통해 현재까지 탐험한 던전 수의 최댓값을 갱신했습니다.
8. 한 경로 탐색이 끝나면 다른 순서도 확인해야 하므로, 방문 처리를 다시 해제하는 백트래킹을 사용했습니다.

### ☄️ 트러블 슈팅

처음에는 던전을 최소 필요 피로도나 소모 피로도 기준으로 정렬해서 탐험하면 된다고 생각했지만 이 문제는 던전의 순서에 따라 탐험 가능한 개수가 달라질 수 있기 때문에, 단순 정렬만으로는 항상 최댓값을 보장할 수 없었습니다.

예를 들어 소모 피로도가 작은 던전부터 가는 것이 좋아 보일 수 있지만, 최소 필요 피로도가 높은 던전을 먼저 가지 않으면 이후에 피로도가 부족해져 탐험하지 못하는 경우가 생길 수 있었기 때문에 모든 던전 순서를 확인하는 DFS 방식으로 접근을 바꾸었습니다.

또한 한 번 방문한 던전은 같은 탐색 경로에서 다시 방문하면 안 되기 때문에 `visited` 배열을 사용했고 재귀 호출이 끝난 뒤에는 다른 경로에서 해당 던전을 다시 선택할 수 있어야 하므로 `visited[i] = false`로 되돌리는 백트래킹 처리가 필요했고 마지막으로 탐험을 더 이상 진행할 수 없는 경우에도 현재까지의 탐험 횟수가 정답이 될 수 있으므로, DFS가 호출될 때마다 `answer`를 갱신하도록 처리했습니다.