### PR TITLE
Week12 문제 풀이 / sooloin

### DIFF
--- a/sooloin/week_12/등굣길/solution.js
+++ b/sooloin/week_12/등굣길/solution.js
@@ -1,0 +1,28 @@
+function solution(m, n, puddles) {
+  const MOD = 1000000007;
+
+  const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));
+
+  const puddleSet = new Set();
+
+  for (const [x, y] of puddles) {
+    puddleSet.add(`${y},${x}`);
+  }
+
+  dp[1][1] = 1;
+
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      if (i === 1 && j === 1) continue;
+
+      if (puddleSet.has(`${i},${j}`)) {
+        dp[i][j] = 0;
+        continue;
+      }
+
+      dp[i][j] = (dp[i - 1][j] + dp[i][j - 1]) % MOD;
+    }
+  }
+
+  return dp[n][m];
+}

--- a/sooloin/week_12/땅따먹기/solution.js
+++ b/sooloin/week_12/땅따먹기/solution.js
@@ -1,0 +1,10 @@
+function solution(land) {
+  for (let i = 1; i < land.length; i++) {
+    land[i][0] += Math.max(land[i - 1][1], land[i - 1][2], land[i - 1][3]);
+    land[i][1] += Math.max(land[i - 1][0], land[i - 1][2], land[i - 1][3]);
+    land[i][2] += Math.max(land[i - 1][0], land[i - 1][1], land[i - 1][3]);
+    land[i][3] += Math.max(land[i - 1][0], land[i - 1][1], land[i - 1][2]);
+  }
+
+  return Math.max(...land[land.length - 1]);
+}

--- a/sooloin/week_12/숫자 변환하기/solution.js
+++ b/sooloin/week_12/숫자 변환하기/solution.js
@@ -1,0 +1,27 @@
+function solution(x, y, n) {
+  const visited = Array(y + 1).fill(-1);
+  const queue = [x];
+
+  visited[x] = 0;
+
+  let head = 0;
+
+  while (head < queue.length) {
+    const current = queue[head++];
+
+    if (current === y) {
+      return visited[current];
+    }
+
+    const nextNumbers = [current + n, current * 2, current * 3];
+
+    for (const next of nextNumbers) {
+      if (next <= y && visited[next] === -1) {
+        visited[next] = visited[current] + 1;
+        queue.push(next);
+      }
+    }
+  }
+
+  return -1;
+}


### PR DESCRIPTION
## Week12 문제 풀이

- #83 

### 📌 이번 주 문제 목록

* [x] 숫자 변환하기
* [x] 등굣길
* [x] 땅따먹기

---

## 1️⃣ 숫자 변환하기

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/154538

### 🤖 핵심 알고리즘

- BFS

### 💻 풀이 코드

```javascript
function solution(x, y, n) {
    const visited = Array(y + 1).fill(-1);
    const queue = [x];

    visited[x] = 0;

    let head = 0;

    while (head < queue.length) {
        const current = queue[head++];

        if (current === y) {
            return visited[current];
        }

        const nextNumbers = [
            current + n,
            current * 2,
            current * 3
        ];

        for (const next of nextNumbers) {
            if (next <= y && visited[next] === -1) {
                visited[next] = visited[current] + 1;
                queue.push(next);
            }
        }
    }

    return -1;
}
```

### 🤔 풀이 방법

1. `x`를 `y`로 만드는 최소 연산 횟수를 구해야 하므로 BFS로 접근함.
2. 시작 숫자 x를 큐에 넣고, `visited` 배열에는 각 숫자까지 도달하는 데 필요한 연산 횟수를 저장함.
3. 현재 숫자에서 가능한 연산은 `+n`, `*2`, `*3`이므로 세 가지 결과를 확인함.
4. 다음 숫자가 y보다 크거나 이미 방문한 숫자라면 제외하고, 방문하지 않은 숫자만 큐에 넣음.
5. BFS는 가까운 거리부터 탐색하기 때문에 y에 처음 도착했을 때의 값이 최소 연산 횟수가 됨.
6. 끝까지 탐색해도 y에 도착하지 못하면 `-1`을 반환함.

### ☄️ 트러블 슈팅

처음에는 가능한 연산을 계속 적용해서 모든 경우를 탐색하면 된다고 생각했음.
하지만 같은 숫자에 여러 방법으로 도달할 수 있어서 중복 탐색이 많이 발생할 수 있었음.
그래서 `visited` 배열을 사용해서 이미 방문한 숫자는 다시 탐색하지 않도록 처리함.

또 이 문제의 연산은 모두 숫자가 커지는 방향이라서, 한 번 y를 넘어가면 다시 돌아올 수 없음.
따라서 `next <= y`인 경우만 큐에 넣도록 수정함.
마지막으로 JavaScript에서 `queue.shift()`를 쓰면 효율성이 떨어질 수 있어서, head 인덱스를 사용해 큐를 처리함.

---

## 2️⃣ 등굣길

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/42898

### 🤖 핵심 알고리즘

- DP

### 💻 풀이 코드

```javascript
function solution(m, n, puddles) {
    const MOD = 1000000007;

    const dp = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));

    const puddleSet = new Set();

    for (const [x, y] of puddles) {
        puddleSet.add(`${y},${x}`);
    }

    dp[1][1] = 1;

    for (let i = 1; i <= n; i++) {
        for (let j = 1; j <= m; j++) {
            if (i === 1 && j === 1) continue;

            if (puddleSet.has(`${i},${j}`)) {
                dp[i][j] = 0;
                continue;
            }

            dp[i][j] = (dp[i - 1][j] + dp[i][j - 1]) % MOD;
        }
    }

    return dp[n][m];
}
```

### 🤔 풀이 방법

1. 이 문제는 집에서 학교까지 이동할 수 있는 최단 경로의 개수를 구하는 문제임.
2. 오른쪽과 아래쪽으로만 이동할 수 있기 때문에, 어떤 칸에 도착하는 방법은 위에서 내려오는 경우와 왼쪽에서 오는 경우 두 가지뿐임.
3. 따라서 각 칸까지 올 수 있는 경로 수를 저장하는 dp 배열을 사용함.
4. `dp[i][j]`는 `(i, j)` 위치까지 올 수 있는 경로의 개수를 의미함.
5. 현재 칸이 물웅덩이가 아니라면, 위쪽 칸의 경로 수와 왼쪽 칸의 경로 수를 더해서 현재 칸의 경로 수를 구함.
    - 식 : `dp[i][j] = dp[i - 1][j] + dp[i][j - 1]` 
6. 물웅덩이인 칸은 지나갈 수 없기 때문에 경로 수를 0으로 처리함.
7. 경로 수가 커질 수 있으므로 문제 조건에 따라 계산할 때마다 `1,000,000,007`로 나눈 나머지를 저장함.
8. 모든 칸을 순회한 뒤, 학교 위치인 dp[n][m] 값을 반환함.

### ☄️ 트러블 슈팅

처음에는 모든 경로를 직접 탐색하는 방식으로 생각했지만, 경우의 수가 많아질 수 있어 DP로 접근함.
`puddles는 [x, y]` 형태로 주어지지만, 2차원 배열은 `[y][x]`로 접근해야 해서 좌표 순서를 주의해야 했음.
시작점 `(1, 1)`은 1로 초기화한 뒤, 반복문에서 다시 계산되지 않도록 따로 건너뛰도록 처리함.
경로 수가 커질 수 있으므로 나머지 연산을 매번 적용해야 했음.

---

## 3️⃣ 땅따먹기

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/12913

### 🤖 핵심 알고리즘

- DP

### 💻 풀이 코드

```javascript
function solution(land) {
    for (let i = 1; i < land.length; i++) {
        land[i][0] += Math.max(land[i - 1][1], land[i - 1][2], land[i - 1][3]);
        land[i][1] += Math.max(land[i - 1][0], land[i - 1][2], land[i - 1][3]);
        land[i][2] += Math.max(land[i - 1][0], land[i - 1][1], land[i - 1][3]);
        land[i][3] += Math.max(land[i - 1][0], land[i - 1][1], land[i - 1][2]);
    }

    return Math.max(...land[land.length - 1]);
}
```

### 🤔 풀이 방법

1. 각 행에서 한 칸씩 선택하면서 내려가야 하고, 바로 이전 행에서 같은 열을 선택할 수 없음.
2. 따라서 현재 칸에 도착할 수 있는 경우는 이전 행의 나머지 3개 열에서 오는 경우뿐임.
3. `land[i][j]`를 `i`행 `j`열을 밟았을 때 얻을 수 있는 최대 점수로 보고, 이전 행에서 같은 열을 제외한 값들 중 최댓값을 더해가며 갱신함.
4. 마지막 행까지 계산한 뒤, 마지막 행의 4개 값 중 가장 큰 값을 반환함.

### ☄️ 트러블 슈팅

처음에는 모든 행에서 가능한 선택을 전부 탐색하려고 생각했었음.
하지만 행의 개수 N이 최대 100,000이기 때문에 모든 경우를 탐색하면 경우의 수가 너무 커짐.

각 행마다 4개의 선택지가 있으므로 단순 탐색은 대략 4^N에 가까워져서 시간 초과가 발생함.
그래서 이전 행까지의 최대 점수를 저장해두고, 현재 행에서는 같은 열을 제외한 최댓값만 참고하는 DP 방식으로 수정함.