### PR TITLE
Week15 문제 풀이 / sooloin

### DIFF
--- a/sooloin/week_15/도넛과 막대 그래프/solution.js
+++ b/sooloin/week_15/도넛과 막대 그래프/solution.js
@@ -1,0 +1,39 @@
+function solution(edges) {
+  const MAX_NODE = 1_000_000;
+
+  const inDegree = new Int32Array(MAX_NODE + 1);
+  const outDegree = new Int32Array(MAX_NODE + 1);
+
+  let maxNode = 0;
+
+  // 각 정점의 진입 차수와 진출 차수를 계산함.
+  for (let i = 0; i < edges.length; i++) {
+    const from = edges[i][0];
+    const to = edges[i][1];
+
+    outDegree[from]++;
+    inDegree[to]++;
+
+    maxNode = Math.max(maxNode, from, to);
+  }
+
+  let createdNode = 0;
+  let stickCount = 0;
+  let eightCount = 0;
+
+  // 정점의 차수 특징을 이용하여 그래프 종류를 판별함.
+  for (let node = 1; node <= maxNode; node++) {
+    if (inDegree[node] === 0 && outDegree[node] >= 2) {
+      createdNode = node;
+    } else if (inDegree[node] >= 1 && outDegree[node] === 0) {
+      stickCount++;
+    } else if (inDegree[node] >= 2 && outDegree[node] === 2) {
+      eightCount++;
+    }
+  }
+
+  const totalCount = outDegree[createdNode];
+  const donutCount = totalCount - stickCount - eightCount;
+
+  return [createdNode, donutCount, stickCount, eightCount];
+}

--- a/sooloin/week_15/전력망을 둘로 나누기/solution.js
+++ b/sooloin/week_15/전력망을 둘로 나누기/solution.js
@@ -1,0 +1,45 @@
+function solution(n, wires) {
+  let answer = Infinity;
+
+  // 1. 그래프 만들기
+  let graph = Array.from({ length: n + 1 }, () => []);
+
+  for (let [a, b] of wires) {
+    graph[a].push(b);
+    graph[b].push(a);
+  }
+
+  // 2. 전선 하나씩 끊기
+  for (let [cutA, cutB] of wires) {
+    let visited = Array(n + 1).fill(false);
+
+    // 3. DFS로 한쪽 네트워크 개수 세기
+    function dfs(cur) {
+      visited[cur] = true;
+      let count = 1;
+
+      for (let next of graph[cur]) {
+        // 끊은 전선이면 지나가지 않기
+        if (
+          (cur === cutA && next === cutB) ||
+          (cur === cutB && next === cutA)
+        ) {
+          continue;
+        }
+
+        if (!visited[next]) {
+          count += dfs(next);
+        }
+      }
+
+      return count;
+    }
+
+    let count = dfs(cutA);
+    let other = n - count;
+
+    answer = Math.min(answer, Math.abs(count - other));
+  }
+
+  return answer;
+}

--- a/sooloin/week_15/표 병합/solution.js
+++ b/sooloin/week_15/표 병합/solution.js
@@ -1,0 +1,124 @@
+function solution(commands) {
+  const SIZE = 50;
+  const CELL_COUNT = SIZE * SIZE;
+
+  const parent = Array.from({ length: CELL_COUNT }, (_, index) => index);
+
+  const value = Array(CELL_COUNT).fill(null);
+  const answer = [];
+
+  const getIndex = (r, c) => {
+    return (r - 1) * SIZE + (c - 1);
+  };
+
+  const find = (x) => {
+    if (parent[x] === x) {
+      return x;
+    }
+
+    parent[x] = find(parent[x]);
+
+    return parent[x];
+  };
+
+  const merge = (first, second) => {
+    const firstRoot = find(first);
+    const secondRoot = find(second);
+
+    if (firstRoot === secondRoot) {
+      return;
+    }
+
+    // 첫 번째 셀의 값을 우선함
+    const mergedValue = value[firstRoot] ?? value[secondRoot];
+
+    parent[secondRoot] = firstRoot;
+
+    value[firstRoot] = mergedValue;
+    value[secondRoot] = null;
+  };
+
+  const unmerge = (target) => {
+    const root = find(target);
+    const savedValue = value[root];
+
+    const members = [];
+
+    // 부모를 변경하기 전에 그룹원을 먼저 찾음
+    for (let i = 0; i < CELL_COUNT; i++) {
+      if (find(i) === root) {
+        members.push(i);
+      }
+    }
+
+    // 모든 셀을 독립된 상태로 되돌림
+    for (const member of members) {
+      parent[member] = member;
+      value[member] = null;
+    }
+
+    // 선택한 위치에만 기존 값을 복구함
+    value[target] = savedValue;
+  };
+
+  for (const command of commands) {
+    const parts = command.split(" ");
+    const type = parts[0];
+
+    if (type === "UPDATE") {
+      // UPDATE r c value
+      if (parts.length === 4) {
+        const r = Number(parts[1]);
+        const c = Number(parts[2]);
+        const newValue = parts[3];
+
+        const index = getIndex(r, c);
+        const root = find(index);
+
+        value[root] = newValue;
+      }
+
+      // UPDATE value1 value2
+      else {
+        const oldValue = parts[1];
+        const newValue = parts[2];
+
+        for (let i = 0; i < CELL_COUNT; i++) {
+          if (parent[i] === i && value[i] === oldValue) {
+            value[i] = newValue;
+          }
+        }
+      }
+    }
+
+    if (type === "MERGE") {
+      const r1 = Number(parts[1]);
+      const c1 = Number(parts[2]);
+      const r2 = Number(parts[3]);
+      const c2 = Number(parts[4]);
+
+      const first = getIndex(r1, c1);
+      const second = getIndex(r2, c2);
+
+      merge(first, second);
+    }
+
+    if (type === "UNMERGE") {
+      const r = Number(parts[1]);
+      const c = Number(parts[2]);
+
+      unmerge(getIndex(r, c));
+    }
+
+    if (type === "PRINT") {
+      const r = Number(parts[1]);
+      const c = Number(parts[2]);
+
+      const root = find(getIndex(r, c));
+
+      answer.push(value[root] ?? "EMPTY");
+    }
+  }
+
+  return answer;
+}


### PR DESCRIPTION
## Week15 문제 풀이

- #106 

### 📌 이번 주 문제 목록

* [x] 도넛과 막대 그래프
* [x] 표 병합
* [x] 전력망을 둘로 나누기

---

## 1️⃣ 도넛과 막대 그래프

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/258711

### 🤖 핵심 알고리즘

- 그래프 차수 분석

### 💻 풀이 코드

```javascript
function solution(edges) {
    const MAX_NODE = 1_000_000;

    const inDegree = new Int32Array(MAX_NODE + 1);
    const outDegree = new Int32Array(MAX_NODE + 1);

    let maxNode = 0;

    // 각 정점의 진입 차수와 진출 차수를 계산함.
    for (let i = 0; i < edges.length; i++) {
        const from = edges[i][0];
        const to = edges[i][1];

        outDegree[from]++;
        inDegree[to]++;

        maxNode = Math.max(maxNode, from, to);
    }

    let createdNode = 0;
    let stickCount = 0;
    let eightCount = 0;

    // 정점의 차수 특징을 이용하여 그래프 종류를 판별함.
    for (let node = 1; node <= maxNode; node++) {
        if (inDegree[node] === 0 && outDegree[node] >= 2) {
            createdNode = node;
        } else if (inDegree[node] >= 1 && outDegree[node] === 0) {
            stickCount++;
        } else if (inDegree[node] >= 2 && outDegree[node] === 2) {
            eightCount++;
        }
    }

    const totalCount = outDegree[createdNode];
    const donutCount = totalCount - stickCount - eightCount;

    return [createdNode, donutCount, stickCount, eightCount];
}
```

### 🤔 풀이 방법

1. 모든 간선을 한 번씩 확인하면서 각 정점으로 들어오는 간선의 수인 **진입 차수**와, 각 정점에서 나가는 간선의 수인 **진출 차수**를 계산함.
2. 생성한 정점은 기존 그래프에 포함되지 않은 새로운 정점이므로 들어오는 간선이 없음. 또한 그래프의 개수가 2개 이상이므로 진입 차수가 0이고 진출 차수가 2 이상인 정점을 생성한 정점으로 판단함.
3. 막대 그래프는 간선을 따라가다 보면 더 이상 이동할 수 없는 마지막 정점이 반드시 존재함. 따라서 진출 차수가 0인 정점의 개수를 세어 막대 그래프의 개수를 구함.
4. 8자 그래프는 두 개의 도넛 그래프가 하나의 정점을 공유하는 구조임. 두 그래프가 만나는 중심 정점에는 간선이 2개 들어오고 2개 나가므로, 진입 차수가 2 이상이고 진출 차수가 2인 정점의 개수를 세어 8자 그래프의 개수를 구함.
5. 생성한 정점에서 나가는 간선의 개수는 연결된 전체 그래프의 개수와 같음. 도넛 그래프에는 막대나 8자처럼 특별한 차수의 정점이 없으므로, 전체 그래프 개수에서 막대 그래프와 8자 그래프의 개수를 빼서 도넛 그래프의 개수를 계산함.


### ☄️ 트러블 슈팅

처음에는 생성한 정점에서 출발하여 각 그래프를 DFS로 탐색하고, 방문한 정점과 간선의 개수를 비교하여 그래프 모양을 구분하려고 했음.
하지만 간선이 최대 1,000,000개이므로 인접 리스트를 만들고 각 그래프를 탐색하면 구현이 복잡해지고 메모리 사용량도 커질 수 있었음.

그래프를 자세히 살펴보니 막대 그래프에는 진출 차수가 0인 정점이 있고, 8자 그래프에는 진출 차수가 2인 중심 정점이 있다는 특징을 발견함.
따라서 그래프를 직접 탐색하지 않고 각 정점의 진입 차수와 진출 차수만 계산하도록 수정함.

---

## 2️⃣ 표 병합

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/150366

### 🤖 핵심 알고리즘

- Union-Find
- 시뮬레이션

### 💻 풀이 코드

```javascript
function solution(commands) {
  const SIZE = 50;
  const CELL_COUNT = SIZE * SIZE;

  const parent = Array.from(
    { length: CELL_COUNT },
    (_, index) => index
  );

  const value = Array(CELL_COUNT).fill(null);
  const answer = [];

  const getIndex = (r, c) => {
    return (r - 1) * SIZE + (c - 1);
  };

  const find = (x) => {
    if (parent[x] === x) {
      return x;
    }

    parent[x] = find(parent[x]);

    return parent[x];
  };

  const merge = (first, second) => {
    const firstRoot = find(first);
    const secondRoot = find(second);

    if (firstRoot === secondRoot) {
      return;
    }

    // 첫 번째 셀의 값을 우선함
    const mergedValue =
      value[firstRoot] ?? value[secondRoot];

    parent[secondRoot] = firstRoot;

    value[firstRoot] = mergedValue;
    value[secondRoot] = null;
  };

  const unmerge = (target) => {
    const root = find(target);
    const savedValue = value[root];

    const members = [];

    // 부모를 변경하기 전에 그룹원을 먼저 찾음
    for (let i = 0; i < CELL_COUNT; i++) {
      if (find(i) === root) {
        members.push(i);
      }
    }

    // 모든 셀을 독립된 상태로 되돌림
    for (const member of members) {
      parent[member] = member;
      value[member] = null;
    }

    // 선택한 위치에만 기존 값을 복구함
    value[target] = savedValue;
  };

  for (const command of commands) {
    const parts = command.split(" ");
    const type = parts[0];

    if (type === "UPDATE") {
      // UPDATE r c value
      if (parts.length === 4) {
        const r = Number(parts[1]);
        const c = Number(parts[2]);
        const newValue = parts[3];

        const index = getIndex(r, c);
        const root = find(index);

        value[root] = newValue;
      }

      // UPDATE value1 value2
      else {
        const oldValue = parts[1];
        const newValue = parts[2];

        for (let i = 0; i < CELL_COUNT; i++) {
          if (
            parent[i] === i &&
            value[i] === oldValue
          ) {
            value[i] = newValue;
          }
        }
      }
    }

    if (type === "MERGE") {
      const r1 = Number(parts[1]);
      const c1 = Number(parts[2]);
      const r2 = Number(parts[3]);
      const c2 = Number(parts[4]);

      const first = getIndex(r1, c1);
      const second = getIndex(r2, c2);

      merge(first, second);
    }

    if (type === "UNMERGE") {
      const r = Number(parts[1]);
      const c = Number(parts[2]);

      unmerge(getIndex(r, c));
    }

    if (type === "PRINT") {
      const r = Number(parts[1]);
      const c = Number(parts[2]);

      const root = find(getIndex(r, c));

      answer.push(value[root] ?? "EMPTY");
    }
  }

  return answer;
}
```

### 🤔 풀이 방법

1. 50 × 50 크기의 표를 1차원 배열로 관리하기 위해 `(r, c)` 좌표를 하나의 인덱스로 변환함.
2. 병합된 셀들을 하나의 그룹으로 관리하기 위해 Union-Find를 사용함. 각 셀은 자신이 속한 그룹의 대표 셀인 루트를 가지며, 실제 값은 루트 셀에만 저장함.
3. `UPDATE r c value` 명령어는 해당 위치의 루트를 찾아 루트에 저장된 값을 변경함.
4. `UPDATE value1 value2` 명령어는 모든 루트 셀을 확인하면서 값이 `value1`인 경우 `value2`로 변경함.
5. `MERGE` 명령어는 두 셀의 루트를 찾은 뒤 하나의 그룹으로 합침. 두 셀 모두 값이 있을 경우 첫 번째 셀의 값을 사용하고, 첫 번째 셀이 비어 있을 경우 두 번째 셀의 값을 사용함.
6. `UNMERGE` 명령어는 선택한 셀이 속한 그룹의 값을 먼저 저장한 뒤, 같은 그룹에 속한 모든 셀을 찾아 각각 독립된 셀로 초기화함. 이후 선택한 위치에만 기존 값을 다시 저장함.
7. `PRINT` 명령어는 선택한 셀의 루트를 찾아 값을 출력하고, 값이 없을 경우 `EMPTY`를 출력함.


### ☄️ 트러블 슈팅
처음에는 병합된 모든 셀에 같은 값을 직접 저장하는 방식으로 접근함. 하지만 값을 수정할 때마다 병합된 셀 전체를 찾아서 변경해야 하고, 셀이 여러 번 병합되면 어떤 셀들이 같은 그룹인지 관리하기 어려웠음.

그래서 병합된 셀을 하나의 그룹으로 묶을 수 있는 Union-Find를 사용하고, 그룹의 루트에만 값을 저장하도록 수정함.

또한 `UNMERGE`에서 그룹을 찾는 동시에 부모를 초기화하면 중간에 연결 관계가 바뀌어 일부 셀을 찾지 못할 수 있었음. 따라서 같은 그룹에 속한 셀들을 먼저 배열에 저장한 뒤, 모든 셀의 병합을 한꺼번에 해제하도록 처리함.

---

## 3️⃣ 전력망을 둘로 나누기

### 🔗 문제

https://school.programmers.co.kr/learn/courses/30/lessons/86971

### 🤖 핵심 알고리즘


### 💻 풀이 코드

```javascript
function solution(n, wires) {
  let answer = Infinity;

  // 1. 그래프 만들기
  let graph = Array.from({ length: n + 1 }, () => []);

  for (let [a, b] of wires) {
    graph[a].push(b);
    graph[b].push(a);
  }

  // 2. 전선 하나씩 끊기
  for (let [cutA, cutB] of wires) {
    let visited = Array(n + 1).fill(false);

    // 3. DFS로 한쪽 네트워크 개수 세기
    function dfs(cur) {
      visited[cur] = true;
      let count = 1;

      for (let next of graph[cur]) {
        // 끊은 전선이면 지나가지 않기
        if (
          (cur === cutA && next === cutB) ||
          (cur === cutB && next === cutA)
        ) {
          continue;
        }

        if (!visited[next]) {
          count += dfs(next);
        }
      }

      return count;
    }

    let count = dfs(cutA);
    let other = n - count;

    answer = Math.min(answer, Math.abs(count - other));
  }

  return answer;
}
```

### 🤔 풀이 방법

1. `wires` 정보를 이용해 송전탑 간의 연결 관계를 **양방향 그래프**로 만듦
2. 전선 하나를 끊으면 전력망이 두 개로 나뉘기 때문에, `wires`를 하나씩 순회하면서 각 전선을 끊었다고 가정함
3. 끊은 전선을 기준으로 DFS를 실행해 한쪽 전력망에 포함된 송전탑의 개수를 구함
4. 한쪽 전력망의 송전탑 개수를 `count`라고 했을 때, 다른 쪽 전력망의 송전탑 개수는 `n - count`로 구함
5. 두 전력망의 송전탑 개수 차이를 `Math.abs(count - (n - count))`로 계산함
6. 모든 전선을 하나씩 끊어보며 계산한 차이 중 가장 작은 값을 `answer`에 저장함
7. 최종적으로 가장 작은 송전탑 개수 차이인 `answer`를 반환함

### ☄️ 트러블 슈팅

처음에는 BFS로 풀어야 하나 고민했지만, 이 문제는 최단거리를 구하는 문제가 아니라 연결된 송전탑의 개수만 세면 되는 문제라고 생각했음.
그래서 큐를 사용하는 BFS보다, 재귀를 이용해 연결된 송전탑을 끝까지 탐색하는 DFS가 더 직관적이라고 판단하여 DFS를 사용함.

또 처음에는 전선을 실제로 그래프에서 삭제해야 하나 고민했다. 하지만 전선을 직접 삭제하면, 다음 전선을 확인할 때 다시 복구해야 해서 코드가 복잡해질 수 있다고 생각함.
그래서 그래프를 수정하지 않고, DFS를 돌릴 때 현재 끊었다고 가정한 전선만 지나가지 않도록 조건문으로 처리함

즉, 현재 위치가 `cutA`이고 다음 위치가 `cutB`인 경우 또는 현재 위치가 `cutB`이고 다음 위치가 `cutA`인 경우에는 탐색하지 않도록 했음.
이렇게 하니까 그래프를 매번 새로 만들거나 전선을 삭제하고 복구하지 않아도, 전선을 하나씩 끊어보는 상황을 깔끔하게 구현할 수 있었음.